### PR TITLE
Fixed build by correcting springloaded dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  springloaded "org.springsource.loaded:springloaded:1.1.5.RELEASE"
+  springloaded "org.springframework:springloaded:1.2.1.RELEASE"
 
   compile ratpack.dependency("h2")
   compile ratpack.dependency("hikari")


### PR DESCRIPTION
[Spring loaded](https://github.com/spring-projects/spring-loaded/) is now available via a different `groupId` than before. Therefore the build couldn't find the artifact which failed the build. I corrected the dependency and updated to the latest version of spring-loaded.

The examble application seems to work fine now but nevertheless it throws a lot of exceptions during runtime like

```
Nov 25, 2014 8:27:48 PM org.springsource.loaded.agent.SpringLoadedPreProcessor preProcess
SEVERE: Unexpected problem transforming call sites
java.lang.IllegalStateException: Unexpected problem processing bytes for class
    at org.springsource.loaded.ConstantPoolChecker2.readConstantPool(ConstantPoolChecker2.java:196)
    at org.springsource.loaded.ConstantPoolChecker2.<init>(ConstantPoolChecker2.java:128)
    at org.springsource.loaded.ConstantPoolChecker2.getReferences(ConstantPoolChecker2.java:102)
    at org.springsource.loaded.MethodInvokerRewriter.rewrite(MethodInvokerRewriter.java:300)
    at org.springsource.loaded.MethodInvokerRewriter.rewriteUsingCache(MethodInvokerRewriter.java:156)
    at org.springsource.loaded.TypeRegistry.methodCallRewriteUseCacheIfAvailable(TypeRegistry.java:828)
    at org.springsource.loaded.agent.SpringLoadedPreProcessor.preProcess(SpringLoadedPreProcessor.java:321)
    at org.springsource.loaded.agent.ClassPreProcessorAgentAdapter.transform(ClassPreProcessorAgentAdapter.java:102)
    at sun.instrument.TransformerManager.transform(TransformerManager.java:188)
    at sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:428)
    at java.lang.ClassLoader.defineClass1(Native Method)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:760)
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:455)
    at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:367)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    at ratpack.rx.internal.ExecControllerBackedScheduler$1.schedule(ExecControllerBackedScheduler.java:72)
    at rx.Scheduler$Worker.schedodically(Scheduler.java:124)
    at rx.internal.util.ObjectPool.<init>(ObjectPool.java:58)
    at rx.internal.util.ObjectPool.<init>(ObjectPool.java:37)
    at rx.internal.util.IndexedRingBuffer$1.<init>(IndexedRingBuffer.java:51)
    at rx.internal.util.IndexedRingBuffer.<clinit>(IndexedRingBuffer.java:51)
    at rx.internal.util.SubscriptionIndexedRingBuffer.<init>(SubscriptionIndexedRingBuffer.java:30)
    at rx.internal.operators.OperatorMerge$MergeSubscriber.handleNewSource(OperatorMerge.java:167)
    at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:160)
    at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:96)
    at rx.internal.operators.OperatorMap$1.onNext(OperatorMap.java:54)
    at ratpack.rx.RxRatpack$ExecutionBackedSubscriber.onNext(RxRatpack.java:510)
    at ratpack.rx.RxRatpack$ExecutionBackedSubscriber.onNext(RxRatpack.java:510)
    at rx.subjects.SubjectSubscriptionManager$SubjectObserver.onNext(SubjectSubscriptionManager.java:224)
    at rx.internal.operators.NotificationLite.accept(NotificationLite.java:147)
    at rx.subjects.ReplaySubject$UnboundedReplayState.accept(ReplaySubject.java:375)
    at rx.subjects.ReplaySubject$UnboundedReplayState.replayObserverFromIndex(ReplaySubject.java:415)
    at rx.subjects.ReplaySubject$UnboundedReplayState.replayObserver(ReplaySubject.java:404)
    at rx.subjects.ReplaySubject.caughtUp(ReplaySubject.java:335)
    at rx.subjects.ReplaySubject.onNext(ReplaySubject.java:295)
    at rx.observers.Subscribers$1.onNext(Subscribers.java:66)
    at ratpack.rx.RxRatpack$ExecutionBackedSubscriber.onNext(RxRatpack.java:510)
    at rx.internal.operators.OperatorDoOnEach$1.onNext(OperatorDoOnEach.java:84)
    at rx.internal.operators.OperatorOnErrorResumeNextViaFunction$1.onNext(OperatorOnErrorResumeNextViaFunction.java:88)
    at ratpack.rx.RxRatpack$ExecutionBackedSubscriber.onNext(RxRatpack.java:510)
    at rx.internal.operators.OperatorDoOnEach$1.onNext(OperatorDoOnEach.java:84)
    at rx.internal.operators.OperatorMap$1.onNext(OperatorMap.java:54)
    at rx.internal.operatratorDoOnEach$1.onNext(OperatorDoOnEach.java:84)
    at rx.internal.operators.OperatorOnErrorResumeNextViaFunction$1.onNext(OperatorOnErrorResumeNextViaFunction.java:88)
    at rx.internal.operators.OperatorMap$1.onNext(OperatorMap.java:54)
    at com.netflix.hystrix.HystrixObservableCommand$HystrixObservableTimeoutOperator$3.onNext(HystrixObservableCommand.java:865)
    at rx.internal.operators.OperatorDoOnEach$1.onNext(OperatorDoOnEach.java:84)
    at ratpack.rx.RxRatpack.lambda$observeEach$5(RxRatpack.java:301)
    at ratpack.rx.RxRatpack$$Lambda$45/510310293.call(Unknown Source)
    at ratpack.rx.RxRatpack$PromiseSubscribe.lambda$call$10(RxRatpack.java:453)
    at ratpack.rx.RxRatpack$PromiseSubscribe$$Lambda$47/1303203566.execute(Unknown Source)
    at ratpack.exec.internal.DefaultSuccessPromise$UserActionFulfiller.success(DefaultSuccessPromise.java:311)
    at ratpack.exec.Fulfiller.accept(Fulfiller.java:102)
    at ratpack.exec.internal.DefaultExecControl.lambda$null$43(DefaultExecControl.java:149)
    at ratpack.exec.internal.DefaultExecControl$$Lambda$52/561822408.execute(Unknown Source)
    at ratpack.exec.internal.ExecutionBacking$1.performOperation(ExecutionBacking.java:268)
    at ratpack.exec.internal.InterceptedOperation.nextInterceptor(InterceptedOperation.java:74)
    at ratpack.exec.internal.InterceptedOperation.lambda$nextInterceptor$24(InterceptedOperation.java:59)
    at ratpack.exec.internal.InterceptedOperation$$Lambda$36/12684081.run(Unknown Source)
    at ratpack.codahale.metrics.internal.BlockingExecTimingInterceptor.intercept(BlockingExecTimingInterceptor.java:42)
    at ratpack.exec.internal.InterceptedOperation.nextInterceptor(InterceptedOperation.java:65)
    at ratpack.exec.internal.InterceptedOperation.run(InterceptedOperation.java:45)
    at ratpack.exec.internal.ExecutionBacking.intercept(ExecutionBacking.java:270)
    at ratpack.exec.internal.ExecutionBacking$UserCodeSegment.run(ExecutionBacking.java:312)
    at ratpack.exec.internal.ExecutionBacking$StreamCompletion.run(ExecutionBacking.java:354)
    at ratpack.exec.internal.ExecutionBackin(ExecutionBacking.java:216)
    at ratpack.exec.internal.ExecutionBacking.access$800(ExecutionBacking.java:34)
    at ratpack.exec.internal.ExecutionBacking$StreamHandle.streamEvent(ExecutionBacking.java:177)
    at ratpack.exec.internal.ExecutionBacking$StreamHandle.complete(ExecutionBacking.java:170)
    at ratpack.exec.internal.DefaultExecControl.lambda$null$44(DefaultExecControl.java:149)
    at ratpack.exec.internal.DefaultExecControl$$Lambda$50/1561372069.accept(Unknown Source)
    at java.util.concurrent.CompletableFuture$ThenAccept.run(CompletableFuture.java:766)
    at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:193)
    at java.util.concurrent.CompletableFuture.internalComplete(CompletableFuture.java:210)
    at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:482)
    at java.util.concurrent.CompletableFuture$Async.run(CompletableFuture.java:428)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at ratpack.exec.internal.DefaultExecController$ExecControllerBindingThreadFactory.lambda$newThread$54(DefaultExecController.java:84)
    at ratpack.exec.internal.DefaultExecController$ExecControllerBindingThreadFactory$$Lambda$3/208043846.run(Unknown Source)
    at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: Entry: 8 18
    at org.springsource.loaded.ConstantPoolChecker2.processConstantPoolEntry(ConstantPoolChecker2.java:335)
    at org.springsource.loaded.ConstantPoolChecker2.readConstantPool(ConstantPoolChecker2.java:186)
    ... 88 more
```
