### PR TITLE
Add no proxy setting.

### DIFF
--- a/src/test/groovy/GebConfig.groovy
+++ b/src/test/groovy/GebConfig.groovy
@@ -1,1 +1,13 @@
+import org.openqa.selenium.firefox.FirefoxDriver
+import org.openqa.selenium.remote.DesiredCapabilities
+import org.openqa.selenium.Proxy
+
+driver = {
+    DesiredCapabilities capabilities = DesiredCapabilities.firefox();
+    Proxy proxy = new Proxy()
+    proxy.setProxyType(Proxy.ProxyType.DIRECT)
+    capabilities.setCapability("proxy", proxy)
+    def driver = new FirefoxDriver(capabilities);
+}
+
 reportsDir = "build/geb-reports"


### PR DESCRIPTION
Use direct connection/ without proxy when executing geb so that it will run smoothly in proxy enabled environment. It is more likely done in local anyway.